### PR TITLE
Core: use the right ODP macro names from ODP_TIME_* family

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,8 +122,8 @@ AC_ARG_WITH([odp],
     [# extend the compiler and linker flags according to the path set
      AM_CPPFLAGS="$AM_CPPFLAGS -I$with_odp/include"
      AM_LDFLAGS="$AM_LDFLAGS -L$with_odp/lib"
-     FIND_LIB_ODP_SO="$with_odp/lib"],
-    [FIND_LIB_ODP_SO=$(dirname $(find /usr/lib /usr/local/lib -type f -name 'libodp.so*')|tail -1)])
+     export PKG_CONFIG_PATH=$with_odp/lib/pkgconfig],
+    [])
 
 ##########################################################################
 # Save and set temporary compilation flags
@@ -132,6 +132,12 @@ OLD_LDFLAGS=$LDFLAGS
 OLD_CPPFLAGS=$CPPFLAGS
 LDFLAGS="$AM_LDFLAGS $LDFLAGS"
 CPPFLAGS="$AM_CPPFLAGS $CPPFLAGS"
+
+PKG_CHECK_MODULES([ODP], [libodp >= 1.4], [ODP_VERSION=104],
+    [PKG_CHECK_MODULES([ODP], [libodp >= 1.3], [ODP_VERSION=103],
+    [PKG_CHECK_MODULES([ODP], [libodp >= 1.2], [ODP_VERSION=102],
+    [PKG_CHECK_MODULES([ODP], [libodp >= 1.0], [ODP_VERSION=100]
+    )])])])
 
 AC_CHECK_LIB(odp, odp_packet_alloc, [],
     [AC_MSG_ERROR(["This package needs OpenDataPlane (libodp.a) installed"])])
@@ -144,7 +150,6 @@ AC_CHECK_HEADERS([odp.h], [],
 LDFLAGS=$OLD_LDFLAGS
 CPPFLAGS=$OLD_CPPFLAGS
 
-ODP_VERSION=$(ls $FIND_LIB_ODP_SO/libodp.so.* -r |head -1 |sed 's|.*libodp.so.||g' |awk -F'.' '{print $1}')
 AC_SUBST(ODP_VERSION)
 
 # Enable/disable OFP_DEBUG

--- a/configure.ac
+++ b/configure.ac
@@ -338,4 +338,5 @@ AC_MSG_RESULT([
 	ldflags:		${LDFLAGS}
 	am_ldflags:		${AM_LDFLAGS}
 	odp_version:		${ODP_VERSION}
+	cunit:			${cunit_support}
 ])

--- a/src/ofp_arp.c
+++ b/src/ofp_arp.c
@@ -24,7 +24,7 @@
 #define NUM_SETS ARP_ENTRY_TABLE_SIZE
 #define NUM_ARPS ARP_ENTRIES_SIZE
 #define CLEANUP_TIMER_INTERVAL (ARP_CLEANUP_TIMER_INTERVAL * SEC_USEC)
-#define ENTRY_TIMEOUT (ARP_ENTRY_TIMEOUT * ODP_TIME_SEC) /* 20 minutes */
+#define ENTRY_TIMEOUT (ARP_ENTRY_TIMEOUT * ODP_TIME_SEC_IN_NS) /* 20 minutes */
 #define ENTRY_UPD_TIMEOUT (ARP_ENTRY_UPD_TIMEOUT * SEC_USEC)
 #define ENTRY_USETIME_INVALID 0xFFFFFFFF
 #define SAVED_PKT_TIMEOUT (ARP_SAVED_PKT_TIMEOUT * SEC_USEC)
@@ -188,7 +188,7 @@ static inline void show_arp_entry(int fd, struct arp_entry *entry)
 		    entry->key.vrf,
 		    ofp_print_ip_addr(entry->key.ipv4_addr),
 		    ofp_print_mac((uint8_t *)&entry->macaddr),
-		    odp_time_cycles_to_ns(diff) / ODP_TIME_SEC);
+                    odp_time_cycles_to_ns(diff) / ODP_TIME_SEC_IN_NS);
 }
 
 static inline void *pkt_entry_alloc(void)

--- a/src/ofp_init.c
+++ b/src/ofp_init.c
@@ -113,7 +113,9 @@ int ofp_init_pre_global(const char *pool_name,
 	HANDLE_ERROR(ofp_global_config_alloc_shared_memory());
 	memset(shm, 0, sizeof(*shm));
 	shm->is_running = 1;
+#ifdef SP
 	shm->nl_thread_is_running = 0;
+#endif /* SP */
 	shm->cli_thread_is_running = 0;
 
 	ofp_register_sysctls();
@@ -418,11 +420,13 @@ int ofp_term_global(void)
 	/* Terminate CLI thread*/
 	CHECK_ERROR(ofp_stop_cli_thread(), rc);
 
+#ifdef SP
 	/* Terminate Netlink thread*/
 	if (shm->nl_thread_is_running) {
 		odph_linux_pthread_join(&shm->nl_thread, 1);
 		shm->nl_thread_is_running = 0;
 	}
+#endif /* SP */
 
 	/* Cleanup interfaces: queues and pktios*/
 	for (i = 0; i < VXLAN_PORTS; i++) {

--- a/src/ofp_portconf.c
+++ b/src/ofp_portconf.c
@@ -146,7 +146,7 @@ static int iter_vlan(void *key, void *iter_arg)
 			    iface->sp_status ? "on" : "off");
 #else
 		ofp_sendf(fd, "gre%d\r\n", iface->vlan);
-#endif
+#endif /* SP */
 
 		if (iface->vrf)
 			ofp_sendf(fd, "	VRF: %d\r\n", iface->vrf);
@@ -186,7 +186,7 @@ static int iter_vlan(void *key, void *iter_arg)
 			    iface->sp_status ? "on" : "off");
 #else
 		ofp_sendf(fd, "vxlan%d\r\n", iface->vlan);
-#endif
+#endif /* SP */
 
 		if (iface->vrf)
 			ofp_sendf(fd, "	VRF: %d\r\n", iface->vrf);
@@ -232,7 +232,7 @@ static int iter_vlan(void *key, void *iter_arg)
 			iface->port,
 			iface->vlan ? buf : "",
 			iface->if_name);
-#endif
+#endif /* SP */
 
 		if (iface->vrf)
 			ofp_sendf(fd, "	VRF: %d\r\n", iface->vrf);
@@ -309,6 +309,7 @@ int free_key(void *key)
 	return 1;
 }
 
+#ifdef SP
 static int exec_sys_call_depending_on_vrf(const char *cmd, uint16_t vrf)
 {
 	char buf[PATH_MAX];
@@ -340,6 +341,7 @@ static int exec_sys_call_depending_on_vrf(const char *cmd, uint16_t vrf)
 	snprintf(buf, sizeof(buf), "ip netns exec vrf%d %s", vrf, cmd);
 	return system(buf);
 }
+#endif /* SP */
 
 const char *ofp_config_interface_up_v4(int port, uint16_t vlan, uint16_t vrf,
 			uint32_t addr, int masklen)
@@ -353,7 +355,7 @@ const char *ofp_config_interface_up_v4(int port, uint16_t vlan, uint16_t vrf,
 
 #ifdef SP
 	(void)ret;
-#endif
+#endif /*SP*/
 	if (port < 0 || port >= OFP_FP_INTERFACE_MAX)
 		return "Wrong port number";
 
@@ -470,7 +472,7 @@ const char *ofp_config_interface_up_tun(int port, uint16_t greid,
 #ifdef SP
 	(void)ret;
 	(void)new;
-#endif
+#endif /*SP*/
 
 	if (port != GRE_PORTS || greid == 0)
 		return "Wrong port number or tunnel ID.";
@@ -582,7 +584,7 @@ const char *ofp_config_interface_up_vxlan(uint16_t vrf, uint32_t addr, int mlen,
 #ifdef SP
 	(void)ret;
 	(void)new;
-#endif
+#endif /*SP*/
 	(void)vrf; /* vrf is copied from the root device */
 
 	dev_root = ofp_get_ifnet(physport, physvlan);
@@ -659,7 +661,7 @@ const char *ofp_config_interface_up_v6(int port, uint16_t vlan,
 
 #ifdef SP
 	(void)ret;
-#endif
+#endif /*SP*/
 	memset(gw6, 0, 16);
 
 	if (port < 0 || port >= OFP_FP_INTERFACE_MAX)
@@ -749,7 +751,7 @@ const char *ofp_config_interface_down(int port, uint16_t vlan)
 
 #ifdef SP
 	(void)ret;
-#endif
+#endif /*SP*/
 	memset(gw6, 0, 16);
 
 	if (port < 0 || port >= shm->ofp_num_ports)
@@ -767,7 +769,7 @@ const char *ofp_config_interface_down(int port, uint16_t vlan)
 
 #ifdef SP
 		vrf = data->vrf;
-#endif
+#endif /*SP*/
 		if (data->ip_addr) {
 			ofp_set_route_params(OFP_ROUTE_DEL, data->vrf, vlan, port,
 					     (data->port == GRE_PORTS) ? data->ip_p2p : data->ip_addr,
@@ -819,7 +821,7 @@ const char *ofp_config_interface_down(int port, uint16_t vlan)
 
 #ifdef SP
 		vrf = data->vrf;
-#endif
+#endif /*SP*/
 		if (data->ip_addr) {
 			ofp_set_route_params(OFP_ROUTE_DEL, data->vrf, 0 /*vlan*/, port,
 					     data->ip_addr, data->masklen, 0 /*gw*/);
@@ -847,7 +849,7 @@ const char *ofp_config_interface_down(int port, uint16_t vlan)
 				 data->ip6_prefix);
 
 			ret = exec_sys_call_depending_on_vrf(cmd, vrf);
-#endif
+#endif /*SP*/
 			memset(data->ip6_addr, 0, 16);
 
 			/* Remove interface from the if_addr v4 queue */
@@ -1178,7 +1180,7 @@ odp_queue_t ofp_pktio_spq_get(odp_pktio_t pktio)
 	(void)pktio;
 
 	return ODP_QUEUE_INVALID;
-#endif
+#endif /*SP*/
 }
 
 odp_queue_t ofp_pktio_loopq_get(odp_pktio_t pktio)
@@ -1261,7 +1263,9 @@ int ofp_portconf_init_global(void)
 		shm->ofp_ifnet_data[i].outq_def = ODP_QUEUE_INVALID;
 		shm->ofp_ifnet_data[i].inq_def = ODP_QUEUE_INVALID;
 		shm->ofp_ifnet_data[i].loopq_def = ODP_QUEUE_INVALID;
+#ifdef SP
 		shm->ofp_ifnet_data[i].spq_def = ODP_QUEUE_INVALID;
+#endif /*SP*/
 		shm->ofp_ifnet_data[i].pkt_pool = ODP_POOL_INVALID;
 	}
 

--- a/src/ofp_timer.c
+++ b/src/ofp_timer.c
@@ -152,9 +152,9 @@ int ofp_timer_init_global(int resolution_us,
 
 	/* Timer pool */
 	memset(&timer_params, 0, sizeof(timer_params));
-	timer_params.res_ns = resolution_us*ODP_TIME_USEC;
-	timer_params.min_tmo = min_us*ODP_TIME_USEC;
-	timer_params.max_tmo = max_us*ODP_TIME_USEC;
+	timer_params.res_ns = resolution_us*ODP_TIME_USEC_IN_NS;
+	timer_params.min_tmo = min_us*ODP_TIME_USEC_IN_NS;
+	timer_params.max_tmo = max_us*ODP_TIME_USEC_IN_NS;
 	timer_params.num_timers = TIMER_NUM_TIMERS;
 	timer_params.priv = 0; /* Shared */
 	timer_params.clk_src = ODP_CLOCK_CPU;
@@ -326,7 +326,7 @@ odp_timer_t ofp_timer_start(uint64_t tmo_us, ofp_timer_callback callback,
 		}
 		bufdata->t_ev = odp_timeout_to_event(tmo);
 
-		period_ns = tmo_us*ODP_TIME_USEC;
+		period_ns = tmo_us*ODP_TIME_USEC_IN_NS;
 		period    = odp_timer_ns_to_tick(shm->socket_timer_pool, period_ns);
 		tick      = odp_timer_current_tick(shm->socket_timer_pool);
 		tick     += period;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -8,8 +8,8 @@ AM_CPPFLAGS += -I$(top_srcdir)/include/api
 
 LDADD = $(top_builddir)/lib/libofp.la
 
-check_PROGRAMS = cpp_test redefinitions_posix_test
+bin_PROGRAMS = cpp_test redefinitions_posix_test
 
-TESTS = ${check_PROGRAMS}
+TESTS = ${bin_PROGRAMS}
 
 cpp_test_SOURCES = cpp_test.cpp

--- a/test/cunit/Makefile.am
+++ b/test/cunit/Makefile.am
@@ -28,7 +28,7 @@ AM_LDFLAGS += -static -lcunit
 
 LDADD = $(top_builddir)/lib/libofp.la
 
-check_PROGRAMS = \
+bin_PROGRAMS = \
 	ofp_test_arp \
 	ofp_test_debug_pcap \
 	ofp_test_debug_print \
@@ -42,6 +42,6 @@ check_PROGRAMS = \
 	ofp_test_in_cksum \
 	ofp_test_init
 
-TESTS = ${check_PROGRAMS}
+TESTS = ${bin_PROGRAMS}
 
 CLEANFILES = $(wildcard *.xml) packets.txt testbuf.txt test.pcap


### PR DESCRIPTION
The latest version of ODP, have renamed the ODP_TIME macros, the new definitions is
as follows:

  /* Time in nanoseconds */
  #define ODP_TIME_USEC_IN_NS     1000ULL       /**< Microsecond in nsec */
  #define ODP_TIME_MSEC_IN_NS     1000000ULL    /**< Millisecond in nsec */
  #define ODP_TIME_SEC_IN_NS      1000000000ULL /**< Second in nsec */

This patch fix the macros name so the program can compile properly.

Signed-off-by: Eduardo Silva <eduardo@monkey.io>