### PR TITLE
examples: postpone printing info messages

### DIFF
--- a/example/classifier/classifier_main.c
+++ b/example/classifier/classifier_main.c
@@ -63,9 +63,6 @@ int main(int argc, char *argv[])
 	/* Parse and store the application arguments */
 	parse_args(argc, argv, &params);
 
-	/* Print both system and application information */
-	print_info(NO_PATH(argv[0]), &params);
-
 	if (odp_init_global(NULL, NULL)) {
 		OFP_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
@@ -74,6 +71,9 @@ int main(int argc, char *argv[])
 		OFP_ERR("Error: ODP local init failed.\n");
 		exit(EXIT_FAILURE);
 	}
+
+	/* Print both system and application information */
+	print_info(NO_PATH(argv[0]), &params);
 
 	core_count = odp_cpu_count();
 	num_workers = core_count;

--- a/example/fpm/app_main.c
+++ b/example/fpm/app_main.c
@@ -111,9 +111,6 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	/* Print both system and application information */
-	print_info(NO_PATH(argv[0]), &params);
-
 	/*
 	 * Before any ODP API functions can be called, we must first init the ODP
 	 * globals, e.g. availale accelerators or software implementations for
@@ -136,6 +133,9 @@ int main(int argc, char *argv[])
 		odp_term_global();
 		return EXIT_FAILURE;
 	}
+
+	/* Print both system and application information */
+	print_info(NO_PATH(argv[0]), &params);
 
 	/*
 	 * Get the number of cores available to ODP, one run-to-completion thread

--- a/example/fpm_burstmode/app_main.c
+++ b/example/fpm_burstmode/app_main.c
@@ -160,9 +160,6 @@ int main(int argc, char *argv[])
 	/* Parse and store the application arguments */
 	parse_args(argc, argv, &params);
 
-	/* Print both system and application information */
-	print_info(NO_PATH(argv[0]), &params);
-
 	if (odp_init_global(NULL, NULL)) {
 		OFP_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
@@ -171,6 +168,9 @@ int main(int argc, char *argv[])
 		OFP_ERR("Error: ODP local init failed.\n");
 		exit(EXIT_FAILURE);
 	}
+
+	/* Print both system and application information */
+	print_info(NO_PATH(argv[0]), &params);
 
 	memset(thread_tbl, 0, sizeof(thread_tbl));
 	memset(pktio_thr_args, 0, sizeof(pktio_thr_args));

--- a/example/ioctl_test/app_main.c
+++ b/example/ioctl_test/app_main.c
@@ -143,9 +143,6 @@ int main(int argc, char *argv[])
 	/* Parse and store the application arguments */
 	parse_args(argc, argv, &params);
 
-	/* Print both system and application information */
-	print_info(NO_PATH(argv[0]), &params);
-
 	if (odp_init_global(NULL, NULL)) {
 		OFP_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
@@ -154,6 +151,9 @@ int main(int argc, char *argv[])
 		OFP_ERR("Error: ODP local init failed.\n");
 		exit(EXIT_FAILURE);
 	}
+
+	/* Print both system and application information */
+	print_info(NO_PATH(argv[0]), &params);
 
 	core_count = odp_cpu_count();
 	num_workers = core_count;

--- a/example/multicast/app_main.c
+++ b/example/multicast/app_main.c
@@ -78,9 +78,6 @@ int main(int argc, char *argv[])
 	/* Parse and store the application arguments */
 	parse_args(argc, argv, &params);
 
-	/* Print both system and application information */
-	print_info(NO_PATH(argv[0]), &params);
-
 	if (odp_init_global(NULL, NULL)) {
 		OFP_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
@@ -89,6 +86,9 @@ int main(int argc, char *argv[])
 		OFP_ERR("Error: ODP local init failed.\n");
 		exit(EXIT_FAILURE);
 	}
+
+	/* Print both system and application information */
+	print_info(NO_PATH(argv[0]), &params);
 
 	core_count = odp_cpu_count();
 	num_workers = core_count;

--- a/example/socket/socket_main.c
+++ b/example/socket/socket_main.c
@@ -75,9 +75,6 @@ int main(int argc, char *argv[])
 	/* Parse and store the application arguments */
 	parse_args(argc, argv, &params);
 
-	/* Print both system and application information */
-	print_info(NO_PATH(argv[0]), &params);
-
 	if (odp_init_global(NULL, NULL)) {
 		OFP_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
@@ -86,6 +83,9 @@ int main(int argc, char *argv[])
 		OFP_ERR("Error: ODP local init failed.\n");
 		exit(EXIT_FAILURE);
 	}
+
+	/* Print both system and application information */
+	print_info(NO_PATH(argv[0]), &params);
 
 	core_count = odp_cpu_count();
 	num_workers = core_count;

--- a/example/sysctl/app_main.c
+++ b/example/sysctl/app_main.c
@@ -71,9 +71,6 @@ int main(int argc, char *argv[])
 	/* Parse and store the application arguments */
 	parse_args(argc, argv, &params);
 
-	/* Print both system and application information */
-	print_info(NO_PATH(argv[0]), &params);
-
 	if (odp_init_global(NULL, NULL)) {
 		OFP_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
@@ -82,6 +79,9 @@ int main(int argc, char *argv[])
 		OFP_ERR("Error: ODP local init failed.\n");
 		exit(EXIT_FAILURE);
 	}
+
+	/* Print both system and application information */
+	print_info(NO_PATH(argv[0]), &params);
 
 	core_count = odp_cpu_count();
 	num_workers = core_count;

--- a/example/udp_fwd_socket/app_main.c
+++ b/example/udp_fwd_socket/app_main.c
@@ -137,14 +137,17 @@ int main(int argc, char *argv[])
 	/* Parse and store the application arguments */
 	parse_args(argc, argv, &params);
 
-	/* Print both system and application information */
-	print_info(NO_PATH(argv[0]), &params);
-
 	if (odp_init_global(NULL, NULL)) {
 		OFP_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}
-	odp_init_local(ODP_THREAD_CONTROL);
+	if (odp_init_local(ODP_THREAD_CONTROL)) {
+		OFP_ERR("Error: ODP local init failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	/* Print both system and application information */
+	print_info(NO_PATH(argv[0]), &params);
 
 	memset(&app_init_params, 0, sizeof(app_init_params));
 	app_init_params.linux_core_id = 0;

--- a/example/udpecho/app_main.c
+++ b/example/udpecho/app_main.c
@@ -79,9 +79,6 @@ int main(int argc, char *argv[])
 	/* Parse and store the application arguments */
 	parse_args(argc, argv, &params);
 
-	/* Print both system and application information */
-	print_info(NO_PATH(argv[0]), &params);
-
 	if (odp_init_global(NULL, NULL)) {
 		OFP_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
@@ -90,6 +87,9 @@ int main(int argc, char *argv[])
 		OFP_ERR("Error: ODP local init failed.\n");
 		exit(EXIT_FAILURE);
 	}
+
+	/* Print both system and application information */
+	print_info(NO_PATH(argv[0]), &params);
 
 	core_count = odp_cpu_count();
 	num_workers = core_count;

--- a/example/webserver/app_main.c
+++ b/example/webserver/app_main.c
@@ -78,9 +78,6 @@ int main(int argc, char *argv[])
 	/* Parse and store the application arguments */
 	parse_args(argc, argv, &params);
 
-	/* Print both system and application information */
-	print_info(NO_PATH(argv[0]), &params);
-
 	if (odp_init_global(NULL, NULL)) {
 		OFP_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
@@ -89,6 +86,9 @@ int main(int argc, char *argv[])
 		OFP_ERR("Error: ODP local init failed.\n");
 		exit(EXIT_FAILURE);
 	}
+
+	/* Print both system and application information */
+	print_info(NO_PATH(argv[0]), &params);
 
 	core_count = odp_cpu_count();
 	num_workers = core_count;

--- a/example/webserver2/app_main.c
+++ b/example/webserver2/app_main.c
@@ -84,9 +84,6 @@ int main(int argc, char *argv[])
 	/* Parse and store the application arguments */
 	parse_args(argc, argv, &params);
 
-	/* Print both system and application information */
-	print_info(NO_PATH(argv[0]), &params);
-
 	if (odp_init_global(NULL, NULL)) {
 		OFP_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
@@ -95,6 +92,9 @@ int main(int argc, char *argv[])
 		OFP_ERR("Error: ODP local init failed.\n");
 		exit(EXIT_FAILURE);
 	}
+
+	/* Print both system and application information */
+	print_info(NO_PATH(argv[0]), &params);
 
 	core_count = odp_cpu_count();
 	num_workers = core_count;


### PR DESCRIPTION
For some ODP implementations need to init ODP globals even
before showing general information about ODP platform.
Does not affect functionality, but can improve user experience
during testing OFP within unstable ODP environment