### PR TITLE
ensure igi_gq is initialized

### DIFF
--- a/src/ofp_igmp.c
+++ b/src/ofp_igmp.c
@@ -662,7 +662,7 @@ igi_alloc_locked(/*const*/ struct ofp_ifnet *ifp)
 
 	IGMP_LOCK_ASSERT();
 
-	igi = malloc(sizeof(struct ofp_igmp_ifinfo));
+	igi = calloc(1, sizeof(struct ofp_igmp_ifinfo));
 	if (igi == NULL)
 		goto out;
 


### PR DESCRIPTION
This fixes a crash caused by garbage in igi_gq when trying to drain the
queue in igi_delete_locked()

Signed-off-by: Ruslan Babayev <ruslan@babayev.com>