### PR TITLE
improve the timer functions so that they would not be inconsistent for either case of single or multiple timer queues

### DIFF
--- a/src/ofp_timer.c
+++ b/src/ofp_timer.c
@@ -362,6 +362,10 @@ odp_timer_t ofp_timer_start_cpu_id(uint64_t tmo_us, ofp_timer_callback callback,
 		return ODP_TIMER_INVALID;
 	}
 
+#if !((defined OFP_RSS) || (defined OFP_TCP_MULTICORE_TIMERS))
+	cpu_id = -1;
+#endif
+
 	bufdata = (struct ofp_timer_internal *)odp_buffer_addr(buf);
 	bufdata->callback = callback;
 	bufdata->buf = buf;
@@ -541,7 +545,14 @@ odp_timer_pool_t ofp_timer(int timer_num)
 
 odp_queue_t ofp_timer_queue_cpu(int cpu_id)
 {
+#if !((defined OFP_RSS) || (defined OFP_TCP_MULTICORE_TIMERS))
+	cpu_id = -1;
+#endif
+
 	if (!shm || cpu_id > OFP_MAX_NUM_CPU)
 		return ODP_QUEUE_INVALID;
-	return shm->queue_per_cpu[cpu_id];
+	else if (cpu_id == -1)
+		return shm->queue;
+	else
+		return shm->queue_per_cpu[cpu_id];
 }


### PR DESCRIPTION
When playing with nginx_ofp, I occasionally found that the nginx can't retransmit the lost packets to client, even though I sync ofp source code to [7fe4a59](https://github.com/OpenFastPath/ofp/commit/7fe4a5955c61b441e0afb2284c719c9c71632261) with  several timer fix. 

In nginx_ofp, ngx_select_process_events, "odp_queue_t timer_queue = ofp_timer_queue_cpu(odp_cpu_id());", but in ofp tcp timers are set with "callout_reset_on(t_callout, delta, f_callout, tp, cpu);" where  "int cpu = INP_CPU(inp);".  INP_CPU, based on compiling condition, is the real cpu id or -1, that means timer set to per cpu queue or simply a global queue. 

But nginx_ofp always reference to per cpu queue without knowledge of this ofp lib compiling condition, and I think the ofp lib user should not care this detail. Then a better solution is to have these two timer API to agree on the scheme of queue. 


