### PR TITLE
Update ARP to display incomplete entries

### DIFF
--- a/include/ofpi_arp.h
+++ b/include/ofpi_arp.h
@@ -124,8 +124,11 @@ int ofp_ipv4_lookup_arp_entry_idx(uint32_t ipv4_addr, uint16_t vrf,
 int ofp_ipv4_lookup_mac(uint32_t ipv4_addr, unsigned char *ll_addr,
 			struct ofp_ifnet *dev);
 int ofp_ipv4_get_mac_by_idx(unsigned char *ll_addr, uint32_t entry_idx);
-enum ofp_return_code ofp_arp_save_ipv4_pkt(odp_packet_t pkt, struct ofp_nh_entry *nh_param,
-				uint32_t ipv4_addr, struct ofp_ifnet *dev);
+enum ofp_return_code ofp_arp_save_ipv4_pkt(odp_packet_t pkt,
+					   struct ofp_nh_entry *nh_param,
+					   uint32_t ipv4_addr,
+					   uint32_t is_link_local,
+					   struct ofp_ifnet *dev);
 
 void ofp_arp_show_table(int fd);
 void ofp_arp_show_saved_packets(int fd);

--- a/include/ofpi_arp.h
+++ b/include/ofpi_arp.h
@@ -52,6 +52,7 @@ union arp_entry_flags {
 	uint8_t all;
 
 	struct  {
+		uint8_t is_used : 1;
 		uint8_t is_complete : 1;
 		uint8_t is_manual : 1;
 	};
@@ -64,7 +65,6 @@ struct arp_entry {
 	odp_timer_t usetime_upd_tmo;
 	odp_rwlock_t usetime_rwlock;
 
-	odp_bool_t is_valid;
 	union arp_entry_flags flags;
 	uint64_t macaddr;
 	struct pkt_list pkt_list_head;

--- a/include/ofpi_arp.h
+++ b/include/ofpi_arp.h
@@ -107,7 +107,7 @@ int ofp_arp_init_local(void);
 void ofp_arp_term_local(void);
 #ifndef OFP_USE_LIBCK
 int ofp_arp_ipv4_insert_entry(uint32_t ipv4_addr, unsigned char *ll_addr,
-			      uint16_t vrf, odp_bool_t is_valid,
+			      uint16_t vrf, odp_bool_t is_complete,
 			      odp_bool_t is_manual,
 			      uint32_t *entry_idx_out,
 			      struct pkt_list *send_list);
@@ -118,7 +118,7 @@ void ofp_arp_ipv4_remove_entry(uint32_t set, struct arp_entry *entry);
 void ofp_arp_ipv4_remove_entry_idx(uint32_t entry_idx);
 int ofp_arp_inc_ref_count(uint32_t entry_idx);
 int ofp_arp_dec_ref_count(uint32_t entry_idx);
-odp_bool_t ofp_arp_entry_validity(uint32_t entry_idx);
+odp_bool_t ofp_arp_entry_is_complete(uint32_t entry_idx);
 int ofp_ipv4_lookup_arp_entry_idx(uint32_t ipv4_addr, uint16_t vrf,
 				       uint32_t *entry_idx);
 int ofp_ipv4_lookup_mac(uint32_t ipv4_addr, unsigned char *ll_addr,

--- a/include/ofpi_config.h
+++ b/include/ofpi_config.h
@@ -9,8 +9,6 @@
 
 #include "api/ofp_config.h"
 
-#define ARP_SANITY_CHECK 1
-
 /**Maximum number of CPUs.
  * Used to define the size of internal structures. */
 #define OFP_MAX_NUM_CPU 64

--- a/src/ofp_arp_ck.c
+++ b/src/ofp_arp_ck.c
@@ -220,12 +220,16 @@ void ofp_arp_show_table(int fd)
  * TODO, stubs
  */
 
-enum ofp_return_code ofp_arp_save_ipv4_pkt(odp_packet_t pkt, struct ofp_nh_entry *nh_param,
-					   uint32_t ipv4_addr, struct ofp_ifnet *dev)
+enum ofp_return_code ofp_arp_save_ipv4_pkt(odp_packet_t pkt,
+					   struct ofp_nh_entry *nh_param,
+					   uint32_t ipv4_addr,
+					   uint32_t is_link_local,
+					   struct ofp_ifnet *dev)
 {
 	(void) pkt;
 	(void) nh_param;
 	(void) ipv4_addr;
+	(void)is_link_local;
 	(void) dev;
 
 	return OFP_PKT_DROP;

--- a/src/ofp_pkt_processing.c
+++ b/src/ofp_pkt_processing.c
@@ -1000,7 +1000,7 @@ static enum ofp_return_code ofp_ip_output_add_eth(odp_packet_t pkt,
 			       eth->ether_dhost) < 0) {
 		send_arp_request(odata->dev_out, gw);
 		return ofp_arp_save_ipv4_pkt(pkt, odata->nh,
-					     gw, odata->dev_out);
+					     gw, is_link_local, odata->dev_out);
 	}
 	ofp_copy_mac(eth->ether_shost, odata->dev_out->mac);
 


### PR DESCRIPTION
Changes:
- locate correct entry for saved pkts
- show incomplete entries
- use 'is_complete' flag instead of 'if_valid' where that was intended 
- replace 'is_valid' field with 'is_used' flag