### PR TITLE
Fix type to prevent implicit type conversion: uint32_t instead of uint16_t

### DIFF
--- a/src/ofp_ifnet.c
+++ b/src/ofp_ifnet.c
@@ -220,7 +220,7 @@ int ofp_mac_set(struct ofp_ifnet *ifnet)
 /* Set interface MTU*/
 int ofp_mtu_set(struct ofp_ifnet *ifnet)
 {
-	uint16_t max_frame_size = odp_pktout_maxlen(ifnet->pktio);
+	uint32_t max_frame_size = odp_pktout_maxlen(ifnet->pktio);
 
 	ifnet->if_mtu = OFP_MTU_SIZE;
 


### PR DESCRIPTION
This pull request fixes an implicit type conversion in ofp_netif.c, where an uint16_t is used instead of an uint32_t.

Background and impact of this bug:
pcap-implementation (in pcap.c) of pktio interface initializes mtu.size with: `pcap->mtu = PKTIO_PCAP_MTU_MAX;` 
whereas PKTIO_PCAP_MTU_MAX is defined as: `#define PKTIO_PCAP_MTU_MAX (64 * 1024)`. 
`64*1024 = 0x00010000`, when casted to uint16_t this is 0.
Using the pcap implementation causes the following error:
```
I 50 0:585118208 ofp_init.c:438] Slow path threads on core 0
I 52 0:585118208 ofp_ifnet.c:214] Device 'pcap:out=test_out.pcap' addr  02:e9:34:80:73:04
E 52 0:585118208 ofp_ifnet.c:231] odp_pktout_maxlen returned too small value: 0
Error: OFP global init failed.
```  