### PR TITLE
routing: fix support for default gateway

### DIFF
--- a/src/ofp_rt_mtrie_lookup.c
+++ b/src/ofp_rt_mtrie_lookup.c
@@ -587,10 +587,14 @@ ofp_rtl_remove(struct ofp_rtl_tree *tree, uint32_t addr_be, uint32_t masklen)
 
 struct ofp_nh_entry *ofp_rtl_search(struct ofp_rtl_tree *tree, uint32_t addr_be)
 {
-	struct ofp_nh_entry *nh = NULL;
 	struct ofp_rtl_node *elem, *node = tree->root;
+	struct ofp_nh_entry *nh = &node->data[0];
 	uint32_t addr = odp_be_to_cpu_32(addr_be);
 	uint32_t low = 0, high = IPV4_FIRST_LEVEL;
+
+	if (!(nh->flags & OFP_RTL_FLAGS_GATEWAY)) {
+		nh = NULL;
+	};
 
 	for (; high <= IPV4_LENGTH ; low = high, high += IPV4_LEVEL) {
 		elem = find_node(node, addr, low, high);


### PR DESCRIPTION
Issues #147 and #240 complain about a non working default gateway feature. I had the same issue and tried to find solutions.

Routes with a default mask of /1 or larger are working, wheres routes with a netmask of /0 are accepted but not used when it comes to selecting the next hop.

- Option A: Use separate routes with a netmask of "/1" or larger. 
  e.g. `0.0.0.0/1` and `128.0.0.0/1`
- Option B: Fix the code
  The proposed fix initializes `nh` (i.e. next hop) with `tree->root->data[0]` (i.e. mtrie leaf for 0.0.0.0) and resets this to NULL, if this is not a gateway (i.e. `OFP_RTL_FLAGS_GATEWAY` not set). 
  This way, `if (elem->masklen == 0) return nh;` will return the default gateway instead of NULL.