### PR TITLE
ci: Add test run with odp-dpdk

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 env:
   ARCH: x86_64
   CC: gcc
+  CONTAINER_NAMESPACE: ghcr.io/opendataplane/odp-docker-images
+  OS: ubuntu_18.04
 
 jobs:
   Checkpatch:
@@ -56,3 +58,19 @@ jobs:
     - name: Failure log
       if: ${{ failure() }}
       run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+
+  Run_dpdk:
+    runs-on: ubuntu-18.04
+    env:
+      OS: ubuntu_20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        cc: [gcc, clang]
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo docker run -i -v `pwd`:/ofp --privileged --shm-size 8g -e CC="${{matrix.cc}}" -e ARCH="${ARCH}"
+               -e CXX=g++-10 $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-dpdk_20.11 /bin/bash -c "apt-get update && apt install g++-10 && /ofp/scripts/check-dpdk.sh"
+      - name: Failure log
+        if: ${{ failure() }}
+        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done

--- a/configure.ac
+++ b/configure.ac
@@ -197,7 +197,7 @@ if test "x$enable_static" = "xyes" ; then
 	export PKG_CONFIG="pkg-config --static"
 fi
 
-PKG_CHECK_MODULES([ODP], [lib$ODP_LIB >= 1.18.0.0], [], [])
+PKG_CHECK_MODULES([ODP], [lib$ODP_LIB >= 1.33.0.0], [], [])
 AC_SUBST([ODP_CFLAGS])
 AC_SUBST([ODP_LIBS])
 

--- a/scripts/check-dpdk.sh
+++ b/scripts/check-dpdk.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -xe
+
+JOBS=${JOBS:-$(nproc)}
+
+if [ "${CC#clang}" != "${CC}" ] ; then
+	export CXX="clang++"
+fi
+
+cd $(readlink -e $(dirname $0))/..
+
+# Configure hugepages
+sysctl vm.nr_hugepages=1000
+mkdir -p /mnt/huge
+mount -t hugetlbfs nodev /mnt/huge
+
+# Build ODP
+git clone https://github.com/OpenDataPlane/odp-dpdk --branch v1.35.0.0_DPDK_19.11 --depth 1
+pushd odp-dpdk
+./bootstrap
+./configure --prefix=$(pwd)/install --enable-deprecated --without-tests --without-examples
+make -j${JOBS} install
+popd
+
+# Build OFP
+./bootstrap
+./configure --with-odp-lib=odp-dpdk --with-odp=$(pwd)/odp-dpdk/install --prefix=$(pwd)/install --enable-cunit
+make -j${JOBS} install
+
+# Test OFP
+make check

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -12,7 +12,7 @@ cd $(readlink -e $(dirname $0))/..
 git clone https://github.com/OpenDataPlane/odp --branch v1.35.0.0 --depth 1
 pushd odp
 ./bootstrap
-./configure --prefix=$(pwd)/install --enable-deprecated
+./configure --prefix=$(pwd)/install --enable-deprecated --without-tests --without-examples
 make -j${JOBS} install
 popd
 

--- a/scripts/devbuild_ofp_odp_dpdk.sh
+++ b/scripts/devbuild_ofp_odp_dpdk.sh
@@ -2,6 +2,10 @@
 
 JOBS=${JOBS:-$(nproc)}
 
+if [ "${CC#clang}" != "${CC}" ] ; then
+	export CXX="clang++"
+fi
+
 cd $(readlink -e $(dirname $0))/..
 
 # Build DPDK
@@ -15,14 +19,14 @@ popd
 popd
 
 # Build ODP
-git clone https://github.com/OpenDataPlane/odp-dpdk --branch v1.35.0.0_DPDK_19.11 --depth 1 ./odp-dpdk
+git clone https://github.com/OpenDataPlane/odp-dpdk --branch v1.35.0.0_DPDK_19.11 --depth 1
 pushd odp-dpdk
 ./bootstrap
-PKG_CONFIG_PATH=$(pwd)/../dpdk/install/lib/x86_64-linux-gnu/pkgconfig ./configure --prefix=$(pwd)/install
+PKG_CONFIG_PATH=$(pwd)/../dpdk/install/lib64/pkgconfig:${PKG_CONFIG_PATH} ./configure --prefix=$(pwd)/install
 make -j${JOBS} install
 popd
 
 # Build OFP
 ./bootstrap
-./configure --with-odp-lib=odp-dpdk --with-odp=$(pwd)/odp-dpdk/install --prefix=$(pwd)/install
+./configure --with-odp-lib=odp-dpdk --with-odp=$(pwd)/odp-dpdk/install --prefix=$(pwd)/install --enable-cunit
 make -j${JOBS} install

--- a/src/ofp_timer.c
+++ b/src/ofp_timer.c
@@ -229,6 +229,10 @@ int ofp_timer_init_global(int resolution_us,
 
 	/* Start one second timeouts */
 	shm->timer_1s = ofp_timer_start(1000000UL, one_sec, NULL, 0);
+	if (shm->timer_1s == ODP_TIMER_INVALID) {
+		OFP_ERR("ofp_timer_start");
+		return -1;
+	}
 
 	return 0;
 }

--- a/test/cunit/ofp_test_arp.c
+++ b/test/cunit/ofp_test_arp.c
@@ -140,8 +140,6 @@ static void test_arp(void)
 	 */
 	uint8_t mac_result[OFP_ETHER_ADDR_LEN + 2];
 
-	CU_ASSERT(0 == ofp_init_local());
-
 	memset(&mock_ifnet, 0, sizeof(mock_ifnet));
 	CU_ASSERT(0 != inet_aton("1.1.1.1", &ip));
 

--- a/test/cunit/ofp_test_arp.c
+++ b/test/cunit/ofp_test_arp.c
@@ -70,7 +70,7 @@ static int init_suite(void)
 	odp_cpumask_t cpumask;
 
 	odp_cpumask_zero(&cpumask);
-	odp_cpumask_set(&cpumask, 0x1);
+	odp_cpumask_set(&cpumask, 0);
 
 	odph_thread_param_init(&thr_params);
 	thr_params.start = pp_thread;

--- a/test/cunit/ofp_test_packet_input.c
+++ b/test/cunit/ofp_test_packet_input.c
@@ -250,7 +250,7 @@ test_init_ifnet(void)
 }
 
 static int
-init_suite(void)
+init_global(void)
 {
 	ofp_global_param_t params;
 
@@ -285,7 +285,7 @@ init_suite(void)
 }
 
 static int
-clean_suite(void)
+term_global(void)
 {
 	if (ofp_term_local())
 		OFP_ERR("Error: OFP local term failed.\n");
@@ -778,7 +778,7 @@ main(void)
 		return CU_get_error();
 
 	/* add a suite to the registry */
-	ptr_suite = CU_add_suite("ofp packet input", init_suite, clean_suite);
+	ptr_suite = CU_add_suite("ofp packet input", NULL, NULL);
 	if (NULL == ptr_suite) {
 		CU_cleanup_registry();
 		return CU_get_error();
@@ -842,7 +842,7 @@ main(void)
 		return CU_get_error();
 	}
 
-	ptr_suite = CU_add_suite("test VRF", init_suite, clean_suite);
+	ptr_suite = CU_add_suite("test VRF", NULL, NULL);
 	if (NULL == ptr_suite) {
 		CU_cleanup_registry();
 		return CU_get_error();
@@ -890,6 +890,11 @@ main(void)
 		return CU_get_error();
 	}
 
+	if (init_global()) {
+		CU_cleanup_registry();
+		return 1;
+	}
+
 #if OFP_TESTMODE_AUTO
 	CU_set_output_filename("CUnit-PKT-IN");
 	CU_automated_run_tests();
@@ -898,6 +903,8 @@ main(void)
 	CU_basic_set_mode(CU_BRM_VERBOSE);
 	CU_basic_run_tests();
 #endif
+
+	(void)term_global();
 
 	nr_of_failed_tests = CU_get_number_of_tests_failed();
 	nr_of_failed_suites = CU_get_number_of_suites_failed();


### PR DESCRIPTION
This series adds to CI a test run with odp-dpdk, and fixes a couple of small problems in test cases to make it work.

v2:
- Tuomas' comments.
- Don't compile ODP tests and examples.

v3:
- Add review tags.
