### PR TITLE
Upgrade to ODP v1.41.0.0

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo docker run -i -v `pwd`:/ofp --privileged --shm-size 8g -e CC="${{matrix.cc}}" -e ARCH="${ARCH}"
-               -e CXX=g++-10 $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-dpdk_20.11 /bin/bash -c "apt-get update && apt install g++-10 && /ofp/scripts/check-dpdk.sh"
+               -e CXX=g++-10 $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-dpdk_22.11 /bin/bash -c "apt-get update && apt install g++-10 && /ofp/scripts/check-dpdk.sh"
       - name: Failure log
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -5,11 +5,11 @@ env:
   ARCH: x86_64
   CC: gcc
   CONTAINER_NAMESPACE: ghcr.io/opendataplane/odp-docker-images
-  OS: ubuntu_18.04
+  OS: ubuntu_20.04
 
 jobs:
   Checkpatch:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:
@@ -39,7 +39,7 @@ jobs:
         ./scripts/ci-checkpatches.sh ${COMMIT_RANGE}
 
   Run_x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -60,7 +60,7 @@ jobs:
       run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
 
   Run_dpdk:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       OS: ubuntu_20.04
     strategy:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Download and build OpenDataPlane (ODP) library:
 
     git clone https://github.com/OpenDataPlane/odp
     cd odp
-    git checkout v1.35.0.0
+    git checkout v1.41.0.0
     ./bootstrap
     ./configure --prefix=<INSTALL ODP TO THIS DIR>
     make

--- a/configure.ac
+++ b/configure.ac
@@ -197,7 +197,7 @@ if test "x$enable_static" = "xyes" ; then
 	export PKG_CONFIG="pkg-config --static"
 fi
 
-PKG_CHECK_MODULES([ODP], [lib$ODP_LIB >= 1.33.0.0], [], [])
+PKG_CHECK_MODULES([ODP], [lib$ODP_LIB >= 1.35.0.0], [], [])
 AC_SUBST([ODP_CFLAGS])
 AC_SUBST([ODP_LIBS])
 

--- a/docs/ofp-user-guide.adoc
+++ b/docs/ofp-user-guide.adoc
@@ -63,7 +63,7 @@ Download and install ODP:
 
  git clone https://github.com/OpenDataPlane/odp
  cd odp
- git checkout v1.35.0.0
+ git checkout v1.41.0.0
  ./bootstrap
  ./configure --prefix=/usr/local
  make install

--- a/example/ioctl_test/app_main.c
+++ b/example/ioctl_test/app_main.c
@@ -97,17 +97,7 @@ static int app_dispatcher_thread(void *arg)
 		printf("App_dispatcher: Error, unexpected event type: %u\n",
 		       odp_event_type(ev));
 
-		/* Free events by type */
-		if (odp_event_type(ev) == ODP_EVENT_BUFFER) {
-			odp_buffer_free(odp_buffer_from_event(ev));
-			continue;
-		}
-
-		if (odp_event_type(ev) == ODP_EVENT_CRYPTO_COMPL) {
-			odp_crypto_compl_free(odp_crypto_compl_from_event(ev));
-			continue;
-		}
-
+		odp_event_free(ev);
 	}
 
 	/* Never reached */

--- a/scripts/check-dpdk.sh
+++ b/scripts/check-dpdk.sh
@@ -17,7 +17,7 @@ mount -t hugetlbfs nodev /mnt/huge
 git clone https://github.com/OpenDataPlane/odp-dpdk --branch v1.41.0.0_DPDK_22.11 --depth 1
 pushd odp-dpdk
 ./bootstrap
-./configure --prefix=$(pwd)/install --enable-deprecated --without-tests --without-examples
+./configure --prefix=$(pwd)/install --without-tests --without-examples
 make -j${JOBS} install
 popd
 

--- a/scripts/check-dpdk.sh
+++ b/scripts/check-dpdk.sh
@@ -14,7 +14,7 @@ mkdir -p /mnt/huge
 mount -t hugetlbfs nodev /mnt/huge
 
 # Build ODP
-git clone https://github.com/OpenDataPlane/odp-dpdk --branch v1.35.0.0_DPDK_19.11 --depth 1
+git clone https://github.com/OpenDataPlane/odp-dpdk --branch v1.41.0.0_DPDK_22.11 --depth 1
 pushd odp-dpdk
 ./bootstrap
 ./configure --prefix=$(pwd)/install --enable-deprecated --without-tests --without-examples

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -9,7 +9,7 @@ fi
 cd $(readlink -e $(dirname $0))/..
 
 # Build ODP
-git clone https://github.com/OpenDataPlane/odp --branch v1.35.0.0 --depth 1
+git clone https://github.com/OpenDataPlane/odp --branch v1.41.0.0 --depth 1
 pushd odp
 ./bootstrap
 ./configure --prefix=$(pwd)/install --enable-deprecated --without-tests --without-examples

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -12,7 +12,7 @@ cd $(readlink -e $(dirname $0))/..
 git clone https://github.com/OpenDataPlane/odp --branch v1.41.0.0 --depth 1
 pushd odp
 ./bootstrap
-./configure --prefix=$(pwd)/install --enable-deprecated --without-tests --without-examples
+./configure --prefix=$(pwd)/install --without-tests --without-examples
 make -j${JOBS} install
 popd
 

--- a/scripts/devbuild_ofp_odp_dpdk.sh
+++ b/scripts/devbuild_ofp_odp_dpdk.sh
@@ -9,7 +9,7 @@ fi
 cd $(readlink -e $(dirname $0))/..
 
 # Build DPDK
-git clone http://dpdk.org/git/dpdk-stable --branch 20.11 --depth 1 ./dpdk
+git clone http://dpdk.org/git/dpdk-stable --branch 22.11 --depth 1 ./dpdk
 pushd dpdk
 meson build
 pushd build
@@ -19,7 +19,7 @@ popd
 popd
 
 # Build ODP
-git clone https://github.com/OpenDataPlane/odp-dpdk --branch v1.35.0.0_DPDK_19.11 --depth 1
+git clone https://github.com/OpenDataPlane/odp-dpdk --branch v1.41.0.0_DPDK_22.11 --depth 1
 pushd odp-dpdk
 ./bootstrap
 PKG_CONFIG_PATH=$(pwd)/../dpdk/install/lib64/pkgconfig:${PKG_CONFIG_PATH} ./configure --prefix=$(pwd)/install

--- a/src/ofp_timer.c
+++ b/src/ofp_timer.c
@@ -427,13 +427,18 @@ odp_timer_t ofp_timer_start_cpu_id(uint64_t tmo_us, ofp_timer_callback callback,
 			return ODP_TIMER_INVALID;
 		}
 
-		t = odp_timer_set_abs(timer, tick, &bufdata->t_ev);
+		odp_timer_start_t param;
+
+		param.tick_type = ODP_TIMER_TICK_ABS;
+		param.tick = tick;
+		param.tmo_ev = bufdata->t_ev;
+		t = odp_timer_start(timer, &param);
 
 		if (t != ODP_TIMER_SUCCESS) {
 			odp_timer_free(timer);
 			odp_timeout_free(tmo);
 			odp_buffer_free(buf);
-			OFP_ERR("odp_timer_set_abs failed");
+			OFP_ERR("odp_timer_start failed");
 			return ODP_TIMER_INVALID;
 		}
 

--- a/src/ofp_timer.c
+++ b/src/ofp_timer.c
@@ -212,7 +212,7 @@ int ofp_timer_init_global(int resolution_us,
 	timer_params.max_tmo = max_us*ODP_TIME_USEC_IN_NS;
 	timer_params.num_timers = TIMER_NUM_TIMERS;
 	timer_params.priv = 0; /* Shared */
-	timer_params.clk_src = ODP_CLOCK_CPU;
+	timer_params.clk_src = ODP_CLOCK_DEFAULT;
 	shm->socket_timer_pool = odp_timer_pool_create("TmrPool",
 						       &timer_params);
 


### PR DESCRIPTION
Upgrade to ODP v1.41.0.0.

- timer: Use odp_timer_start() instead of odp_timer_set_abs()

- timer: Use ODP_CLOCK_DEFAULT instead of ODP_CLOCK_CPU

- example: ioctl_test: Use odp_event_free()
