### PR TITLE
icmp6: remove extra open parenthesis

### DIFF
--- a/src/ofp_icmp6.c
+++ b/src/ofp_icmp6.c
@@ -794,7 +794,7 @@ ofp_icmp6_input(odp_packet_t *m, int *offp, int *nxt)
 		ofp_nd6_ns_input(*m, off, icmp6len);
 #ifndef SP
 		if (icmp6len < (sizeof(struct ofp_nd_neighbor_solicit)  + 8) &&
-			(icmp6_data(icmp6)[20] !=
+			icmp6_data(icmp6)[20] !=
 				OFP_ND_OPT_SOURCE_LINKADDR)
 			goto badlen;
 


### PR DESCRIPTION
An extra open parenthesis seems to have been added in commit 8f7a5f2, which breaks compilation with the --disable-sp configure option. Remove it.

Fixes: 8f7a5f2 icmp6: Fix array-bounds warnings on icmp6 data access